### PR TITLE
Update jekyll-gh-pages.yml

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -35,7 +35,7 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:


### PR DESCRIPTION
Workflow failing as old version in use, upload artifact deprecated as per: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Updated this workflow to use newer version as per: https://github.com/actions/upload-pages-artifact